### PR TITLE
change to home when running dotfiles from another directory then back

### DIFF
--- a/dotfiles.plugin.zsh
+++ b/dotfiles.plugin.zsh
@@ -16,8 +16,8 @@ function dotfiles_hasStagedFiles {
 function dotfiles_gitStage {
   dotfiles_gitInclude
   git add .
-  if dotfiles_hasStagedFiles; 
-  then 
+  if dotfiles_hasStagedFiles;
+  then
     cGreen='\033[0;32m'
     cNone='\033[0m'
     echo -e "Staged changes:\n${cGreen}$(git diff --name-only --cached | cat)${cNone}"
@@ -47,6 +47,9 @@ function dotfiles_gitDownload {
 }
 
 function dotfiles {
+  local current_dir=$(pwd)
+  cd ~
+
   if [ "$1" = "-u" ] || [ "$1" = "--upload" ]
   then
     dotfiles_gitUpload
@@ -65,5 +68,7 @@ Options:
   -d, --download      download dotfiles from remote repository
   -h, --help          print usage interface\
 "
-  fi 
+  fi
+
+  cd $current_dir
 }


### PR DESCRIPTION
When you run `dotfiles -c` in a directory thats not your home directory, you'll get an error about not finding `.gitinclude`.  This plugin assumes your are running `dotfiles` from your home directory, but i have personally found a habit of running it in other places. I believe you should note the current working directory when running `dotfiles` commands then auto cd into home directory, run the command then change back to the directory you were in, since dotfiles runs git commands, you can potentially run git commands on other repositories if youre in a directory that is a git repo.